### PR TITLE
[Nora] Break the auto-updating feature

### DIFF
--- a/resources/updates.py
+++ b/resources/updates.py
@@ -9,7 +9,7 @@ from packaging import version
 
 from resources import constants, network_handler
 
-REPO_LATEST_RELEASE_URL: str = "https://api.github.com/repos/dortania/OpenCore-Legacy-Patcher/releases/latest"
+REPO_LATEST_RELEASE_URL: str = "https://api.github.com/repos/crystall1nedev/OpenCore-Legacy-Patcher/releases/latest"
 
 
 class CheckBinaryUpdates:


### PR DESCRIPTION
This change to OCLP is designed to be used on Nora, with Nora-EFI.

This commit disables the ability for OCLP to automatically install patcher updates from the Dortania repository. If these builds are installed on my Sonoma partition, they will prevent me from being able to install root patches as WhateverGreen is disabled if the OS is not Ventura.